### PR TITLE
Generalize operations links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # D4H Mail Helper Extension
 
-This browser extension simplifies the process of sharing D4H training exercises in emails. It adds a button to the exercises page that copies a formatted list of upcoming events to your clipboard, ready to be pasted into a new message in D4H's communication system.
+This browser extension simplifies the process of sharing D4H links in emails. Originally designed for the Training **Exercises** page, it now works on the Operations tabs such as **Incidents** and **Events**. The extension adds a button to these tables and copies a formatted list of items to your clipboard, ready to be pasted into a new D4H message.
 
-The main functionality is to provide an easy way to generate links for training exercises that are compatible with D4H's e-mail system.
+The main functionality is to provide an easy way to generate email-ready links for any of these pages.
 
 ![Extension Icon](icon.png)
 
 ## Key Features
 
-- **One-Click Copying**: Adds a "Copy Exercises" button to the D4H exercises page.
-- **Chronological Order**: Automatically sorts the exercises from soonest to latest.
+- **One-Click Copying**: Adds a "Copy" button to the list pages (Exercises, Incidents, Events).
+- **Chronological Order**: Automatically sorts the items from soonest to latest.
 - **HTML Formatting**: Creates a clean, bulleted list with clickable links.
 - **Email-Ready**: The copied format is designed to paste perfectly into D4H emails.
 
@@ -43,7 +43,7 @@ No technical knowledge is needed to install this extension. Follow these steps f
 
 ## How to Use
 
-1. Log in to your D4H account and go to the **Team > Exercises** page.
-2. You will see an orange **"Copy Exercises"** button in the top-right corner of the page.
+1. Log in to your D4H account and open one of the list pages (e.g. **Exercises**, **Incidents**, or **Events**).
+2. You will see an orange **"Copy"** button in the top-right corner of the table.
 3. Click the button. A confirmation message will appear, letting you know the list has been copied.
-4. Go to the D4H **Communications** section, compose a new message, and paste the content into the email body. The formatted list of exercises will appear.
+4. Go to the D4H **Communications** section, compose a new message, and paste the content into the email body. The formatted list will appear.

--- a/background.js
+++ b/background.js
@@ -3,13 +3,14 @@
 // Function to inject the content script
 function runContentScript(tab) {
   console.log("D4H Mail Helper: Browser action clicked, attempting to inject script.");
-  if (tab.url && tab.url.includes("/team/exercises")) {
+  const supported = /\/team\/(?:exercises|incidents|events)/.test(tab.url || "");
+  if (supported) {
     chrome.scripting.executeScript({
       target: { tabId: tab.id, allFrames: true },
       files: ["content.js"],
     });
   } else {
-    console.log("D4H Mail Helper: Not a D4H exercises page.");
+    console.log("D4H Mail Helper: Not a supported page.");
   }
 }
 

--- a/content.js
+++ b/content.js
@@ -1,11 +1,20 @@
 (function () {
   // Add version number for debugging
-  const VERSION = "0.3";
+  const VERSION = "0.4";
   console.log(`D4H Mail Helper v${VERSION}: Content script loaded on ${window.location.href}`);
   
   // ----- helper to make <a> … </a> blocks -----------------------------
   const makeAnchor = (href, text) =>
     `<a href="${href}">${text.replace(/\s+/g, " ").trim()}</a>`;
+
+  // Determine which type of items we are on (exercises, incidents, events)
+  const ITEM_LABEL = (() => {
+    const url = window.location.href;
+    if (/\/incidents/.test(url)) return "Incidents";
+    if (/\/events/.test(url)) return "Events";
+    if (/\/exercises/.test(url)) return "Exercises";
+    return "Items";
+  })();
 
   // ----- add the UI button --------------------------------------------
   function addButton() {
@@ -20,7 +29,7 @@
     // --- Create the Button Element ---
     const btn = document.createElement("button");
     btn.id = "d4h-mail-helper-btn";
-    btn.textContent = "Copy Exercises";
+    btn.textContent = `Copy ${ITEM_LABEL}`;
 
     // --- Create the Overlay Container ---
     const overlay = document.createElement("div");
@@ -71,7 +80,7 @@
         // Map rows to HTML list item strings
         const listItems = rows.flatMap((tr) => {
           const links = Array.from(tr.querySelectorAll("a"));
-          const ev = links.find((a) => /\/exercises\/view\//.test(a.href));
+          const ev = links.find((a) => /\/(?:exercises|incidents|events)\/view\//.test(a.href));
           const dt = links.find((a) => /\/calendar\/day/.test(a.href));
 
           if (ev && dt) {
@@ -85,7 +94,7 @@
 
         // If no rows were found, alert the user and stop
         if (!listItems) {
-          alert("No valid exercise rows found to copy.");
+          alert("No valid rows found to copy.");
           return;
         }
 
@@ -161,7 +170,7 @@
       document.body.removeChild(container);
 
       if (success) {
-        alert('Formatted exercise list copied to clipboard (fallback method)!');
+        alert('Formatted list copied to clipboard (fallback method)!');
       } else {
         alert('Could not copy list. See console for details.');
       }

--- a/manifest.json
+++ b/manifest.json
@@ -3,44 +3,70 @@
   "description": "Copy a ready-made exercise list to the clipboard.",
   "version": "0.1",
   "manifest_version": 3,
-  "icons": { 
+  "icons": {
     "16": "icon.png",
-    "48": "icon.png", 
-    "128": "icon.png" 
+    "48": "icon.png",
+    "128": "icon.png"
   },
-
   "action": {
     "default_title": "D4H Mail Helper",
     "default_icon": "icon.png"
   },
-
   "background": {
     "service_worker": "background.js"
   },
-
   "content_scripts": [
     {
       "matches": [
         "*://*.d4h.com/team/exercises*",
-        "*://*.d4h.com/*/team/exercises*", 
+        "*://*.d4h.com/team/incidents*",
+        "*://*.d4h.com/team/events*",
+        "*://*.d4h.com/*/team/exercises*",
+        "*://*.d4h.com/*/team/incidents*",
+        "*://*.d4h.com/*/team/events*",
         "*://d4h.com/team/exercises*",
+        "*://d4h.com/team/incidents*",
+        "*://d4h.com/team/events*",
         "*://d4h.com/*/team/exercises*",
+        "*://d4h.com/*/team/incidents*",
+        "*://d4h.com/*/team/events*",
         "*://*.d4h.org/team/exercises*",
+        "*://*.d4h.org/team/incidents*",
+        "*://*.d4h.org/team/events*",
         "*://*.d4h.org/*/team/exercises*",
+        "*://*.d4h.org/*/team/incidents*",
+        "*://*.d4h.org/*/team/events*",
         "*://app.d4h.com/team/exercises*",
+        "*://app.d4h.com/team/incidents*",
+        "*://app.d4h.com/team/events*",
         "*://app.d4h.com/*/team/exercises*",
+        "*://app.d4h.com/*/team/incidents*",
+        "*://app.d4h.com/*/team/events*",
         "*://secure.d4h.com/team/exercises*",
+        "*://secure.d4h.com/team/incidents*",
+        "*://secure.d4h.com/team/events*",
         "*://secure.d4h.com/*/team/exercises*",
+        "*://secure.d4h.com/*/team/incidents*",
+        "*://secure.d4h.com/*/team/events*",
         "*://*.team-manager.us.d4h.com/team/exercises*",
-        "*://*.team-manager.us.d4h.com/*/team/exercises*"
+        "*://*.team-manager.us.d4h.com/team/incidents*",
+        "*://*.team-manager.us.d4h.com/team/events*",
+        "*://*.team-manager.us.d4h.com/*/team/exercises*",
+        "*://*.team-manager.us.d4h.com/*/team/incidents*",
+        "*://*.team-manager.us.d4h.com/*/team/events*"
       ],
-      "js": ["content.js"],
+      "js": [
+        "content.js"
+      ],
       "run_at": "document_idle",
       "all_frames": true
     }
   ],
-
-  "permissions": ["clipboardWrite", "scripting", "activeTab"],
+  "permissions": [
+    "clipboardWrite",
+    "scripting",
+    "activeTab"
+  ],
   "host_permissions": [
     "*://*.d4h.com/*",
     "*://*.d4h.org/*",


### PR DESCRIPTION
## Summary
- support Incidents and Events in addition to Exercises
- update labels in the page UI and manifest patterns
- inject script whenever on one of the supported operations tabs
- clarify documentation for new behaviour

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68654fd835148330adf542216657d1c5